### PR TITLE
feat!: Use attributes to configure event listeners

### DIFF
--- a/docs/aggregates.md
+++ b/docs/aggregates.md
@@ -11,14 +11,15 @@ newer events to the aggregate to get to the most recent state.
 
 The example below demonstrates how an event is created within an aggregate and how it is handled. Important is that
 within the creation method (`changeName` in the example), no state changed occur. State of the aggregate is only changed
-in event handlers. An event handler should be named after the event, eg `apply[EventName]`. The event handlers are
-called when loading an aggregate from storage (see [aggregate factory](#aggregate-factory)), the creation methods are
-not.
+in event handlers. An event handler must have a `Listener` attribute. You may add attributes for multiple events to a
+single handler, eg have a handler that handles multiple events. The event handlers are called when loading an aggregate
+from storage (see [aggregate factory](#aggregate-factory)), the creation methods are not.
 
 ```php
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRoot;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Event\BaseEvent;
+use MyOnlineStore\EventSourcing\Listener\Attribute\Listener;
 
 final class NameChanged extends BaseEvent
 {
@@ -42,7 +43,8 @@ final class Customer extends AggregateRoot
         $this->recordThat(NameChanged::byCustomer($this->aggregateRootId, $name));
     }
 
-    protected function applyNameChanged(NameChanged $event): void
+    #[Listener(NameChanged::class)]
+    protected function nameChanged(NameChanged $event): void
     {
         $this->name = $event->getName();
     }

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -11,13 +11,14 @@ because every implementation will be very specific for a given `ReadModel`. The 
 `ReadModelNotFound` exception when a model can not be found.
 
 To create, update and delete read models, a basic `Projector` is available that can be extended. It is an event listener
-that can be used together with the `DispatchingEventRepository`. A `ReadModelRepository` implementation is required as
-constructor argument and event handlers must be defined similar to the `AggregateRoot`. Basic usage can be seen in the
-next example, using the `NameChanged` event as defined in [Aggregates](aggregates.md):
+that can be used together with the `DispatchingEventRepository`. Event handlers can be defined similar to how it is done
+in the `AggregateRoot`. Basic usage can be seen in the next example, using the `NameChanged` event as defined in
+[Aggregates](aggregates.md):
 
 ```php
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Exception\ReadModelNotFound;
+use MyOnlineStore\EventSourcing\Listener\Attribute\Listener;
 use MyOnlineStore\EventSourcing\Projection\Projector;
 
 final class CustomerInfoReadModel implements ReadModel
@@ -36,7 +37,8 @@ final class CustomerInfoReadModel implements ReadModel
 
 final class CustomerInfoProjector extends Projector
 {
-    protected function applyNameChanged(NameChanged $event)
+    #[Listener(NameChanged::class)]
+    protected function nameChanged(NameChanged $event)
     {
         try {
             $model = $this->repository->load($event->getAggregateId());

--- a/docs/quickstart.php
+++ b/docs/quickstart.php
@@ -2,12 +2,13 @@
 declare(strict_types=1);
 
 /**
- * Quick start example that shows basic usage
+ * Quick start example that demonstrates basic usage
  */
 
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRoot;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Event\BaseEvent;
+use MyOnlineStore\EventSourcing\Listener\Attribute\Listener;
 
 final class CustomerId extends AggregateRootId
 {
@@ -78,15 +79,17 @@ final class Customer extends AggregateRoot
         $this->recordThat(NameChanged::byCustomer($this->id, $name));
     }
 
-    protected function applyNameChanged(NameChanged $event): void
+    #[Listener(NameChanged::class)]
+    #[Listener(Registered::class)]
+    protected function nameChanged(NameChanged|Registered $event): void
     {
         $this->name = $event->getName();
     }
 
-    protected function applyRegistered(Registered $event): void
+    #[Listener(Registered::class)]
+    protected function registered(Registered $event): void
     {
         $this->id = $event->getCustomerId();
-        $this->name = $event->getName();
         $this->registeredAt = $event->getCreatedAt();
     }
 }

--- a/docs/sql.md
+++ b/docs/sql.md
@@ -28,3 +28,13 @@ CREATE TABLE event_stream_metadata (
     metadata JSONB NOT NULL
 );
 ```
+
+
+## SnapshotRepository
+```postgresql
+CREATE TABLE event_stream_snapshot (
+    aggregate_id UUID PRIMARY KEY,
+    version INT,
+    state TEXT NOT NULL
+);
+```

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm allowPhpStormGenerics="true"
        errorLevel="1"
+       resolveFromConfigFile="true"
        totallyTyped="true"
        usePhpDocMethodsWithoutMagicCall="true"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -8,14 +9,13 @@
        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
-        <directory name="src" />
+        <directory name="src"/>
         <ignoreFiles>
-            <directory name="vendor" />
+            <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
 
     <issueHandlers>
-        <ImplicitToStringCast errorLevel="suppress"/>
         <PropertyNotSetInConstructor errorLevel="suppress"/>
     </issueHandlers>
 

--- a/src/Aggregate/AggregateRootId.php
+++ b/src/Aggregate/AggregateRootId.php
@@ -9,36 +9,29 @@ use Ramsey\Uuid\Uuid;
 
 class AggregateRootId
 {
-    private string $id;
-
-    final private function __construct(string $id)
-    {
-        $this->id = $id;
+    final private function __construct(
+        private string $id
+    ) {
     }
 
     /**
-     * @return static
-     *
      * @throws AssertionFailed
      */
-    public static function fromString(string $aggregateRootId): AggregateRootId
+    public static function fromString(string $aggregateRootId): static
     {
         Assert::uuid($aggregateRootId);
 
         return new static($aggregateRootId);
     }
 
-    /**
-     * @return static
-     */
-    public static function generate(): AggregateRootId
+    public static function generate(): static
     {
         /** @noinspection PhpUnhandledExceptionInspection */
 
         return new static(Uuid::uuid4()->toString());
     }
 
-    public function equals(AggregateRootId $comparator): bool
+    public function equals(self $comparator): bool
     {
         return $this->id === $comparator->id;
     }

--- a/src/Event/EventId.php
+++ b/src/Event/EventId.php
@@ -9,11 +9,9 @@ use Ramsey\Uuid\Uuid;
 
 final class EventId
 {
-    private string $id;
-
-    private function __construct(string $id)
-    {
-        $this->id = $id;
+    private function __construct(
+        private string $id
+    ) {
     }
 
     /**

--- a/src/Exception/ReadModelNotFound.php
+++ b/src/Exception/ReadModelNotFound.php
@@ -9,6 +9,6 @@ final class ReadModelNotFound extends EventSourcingException
 {
     public static function withAggregateRootId(AggregateRootId $aggregateRootId, string $readModel = 'ReadModel'): self
     {
-        return new self(\sprintf('%s not found for aggregate "%s"', $readModel, $aggregateRootId));
+        return new self(\sprintf('%s not found for aggregate "%s"', $readModel, $aggregateRootId->toString()));
     }
 }

--- a/src/Exception/SnapshotNotFound.php
+++ b/src/Exception/SnapshotNotFound.php
@@ -9,6 +9,6 @@ final class SnapshotNotFound extends EventSourcingException
 {
     public static function withAggregateRootId(AggregateRootId $aggregateRootId): self
     {
-        return new self(\sprintf('Snapshot not found for aggregate "%s"', $aggregateRootId));
+        return new self(\sprintf('Snapshot not found for aggregate "%s"', $aggregateRootId->toString()));
     }
 }

--- a/src/Listener/Attribute/Listener.php
+++ b/src/Listener/Attribute/Listener.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace MyOnlineStore\EventSourcing\Listener\Attribute;
+
+/**
+ * @psalm-immutable
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class Listener
+{
+    public function __construct(
+        public string $event
+    ) {
+    }
+}

--- a/src/Listener/AttributeListenerAware.php
+++ b/src/Listener/AttributeListenerAware.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace MyOnlineStore\EventSourcing\Listener;
+
+use MyOnlineStore\EventSourcing\Listener\Attribute\Listener;
+
+trait AttributeListenerAware
+{
+    /** @var array<string, list<callable>> */
+    private array $listeners = [];
+
+    /**
+     * @return array<string, list<callable>>
+     */
+    protected function getListeners(string $event): array
+    {
+        if (empty($this->listeners)) {
+            $reflection = new \ReflectionObject($this);
+
+            foreach ($reflection->getMethods() as $method) {
+                foreach ($method->getAttributes(Listener::class) as $listenerAttribute) {
+                    $listener = $listenerAttribute->newInstance();
+
+                    $this->listeners[$listener->event][] = [$this, $method->getName()];
+                }
+            }
+        }
+
+        /** @psalm-var array<string, list<callable>> */
+        return $this->listeners[$event] ?? [];
+    }
+}

--- a/src/Projection/Projector.php
+++ b/src/Projection/Projector.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 namespace MyOnlineStore\EventSourcing\Projection;
 
 use MyOnlineStore\EventSourcing\Event\Event;
+use MyOnlineStore\EventSourcing\Listener\AttributeListenerAware;
 
 abstract class Projector
 {
+    use AttributeListenerAware;
+
     public function __invoke(Event $event): void
     {
-        $parts = \explode('\\', $event::class);
-
-        $this->{'apply' . \end($parts)}($event);
+        foreach ($this->getListeners($event::class) as $listener) {
+            $listener($event);
+        }
     }
 }

--- a/src/Repository/DBALMetadataRepository.php
+++ b/src/Repository/DBALMetadataRepository.php
@@ -27,17 +27,15 @@ final class DBALMetadataRepository implements MetadataRepository
      */
     public function load(string $streamName, AggregateRootId $aggregateRootId): StreamMetadata
     {
+        /** @psalm-var array{metadata: string}|false $result */
         $result = $this->connection->fetchAssociative(
             'SELECT metadata FROM ' . $streamName . '_metadata WHERE aggregate_id = ?',
             [$aggregateRootId->toString()],
             ['string']
         );
 
-        /** @psalm-var array{metadata: string}|false $result */
-
-        $metadata = $result ? (array) $this->jsonEncoder->decode($result['metadata']) : [];
-
         /** @psalm-var array<string, string> $metadata */
+        $metadata = $result ? (array) $this->jsonEncoder->decode($result['metadata']) : [];
 
         return new StreamMetadata($metadata);
     }

--- a/src/Repository/SnapshottingAggregateRepository.php
+++ b/src/Repository/SnapshottingAggregateRepository.php
@@ -56,7 +56,7 @@ final class SnapshottingAggregateRepository implements AggregateRepository
                     $this->metadataRepository->load($this->streamName, $aggregateRootId)
                 )
             );
-        } catch (SnapshotNotFound $exception) {
+        } catch (SnapshotNotFound) {
         }
 
         return $this->innerRepository->load($aggregateRootId);

--- a/tests/Mock/BaseAggregateRoot.php
+++ b/tests/Mock/BaseAggregateRoot.php
@@ -6,6 +6,7 @@ namespace MyOnlineStore\EventSourcing\Tests\Mock;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRoot;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Event\BaseEvent;
+use MyOnlineStore\EventSourcing\Listener\Attribute\Listener;
 
 final class BaseAggregateRoot extends AggregateRoot
 {
@@ -21,8 +22,9 @@ final class BaseAggregateRoot extends AggregateRoot
         $this->recordThat(BaseEvent::occur($this->aggregateRootId, ['foo' => 'bar']));
     }
 
-    protected function applyBaseEvent(BaseEvent $event): void
+    #[Listener(BaseEvent::class)]
+    protected function applyEvent(BaseEvent $event): void
     {
-        $this->foo = $event->getPayload()['foo'];
+        $this->foo = (string) $event->getPayload()['foo'];
     }
 }

--- a/tests/Mock/BaseProjector.php
+++ b/tests/Mock/BaseProjector.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace MyOnlineStore\EventSourcing\Tests\Mock;
+
+use MyOnlineStore\EventSourcing\Event\BaseEvent;
+use MyOnlineStore\EventSourcing\Listener\Attribute\Listener;
+use MyOnlineStore\EventSourcing\Projection\Projector;
+
+final class BaseProjector extends Projector
+{
+    public function __construct(
+        private \stdClass $model
+    ) {
+    }
+
+    #[Listener(BaseEvent::class)]
+    protected function applyEvent(BaseEvent $event): void
+    {
+        $this->model->foo = $event->getPayload()['foo'];
+    }
+}

--- a/tests/Mock/BaseSnapshottingAggregateRoot.php
+++ b/tests/Mock/BaseSnapshottingAggregateRoot.php
@@ -6,6 +6,7 @@ namespace MyOnlineStore\EventSourcing\Tests\Mock;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Aggregate\SnapshottingAggregateRoot;
 use MyOnlineStore\EventSourcing\Event\BaseEvent;
+use MyOnlineStore\EventSourcing\Listener\Attribute\Listener;
 
 final class BaseSnapshottingAggregateRoot extends SnapshottingAggregateRoot
 {
@@ -21,6 +22,7 @@ final class BaseSnapshottingAggregateRoot extends SnapshottingAggregateRoot
         $this->recordThat(BaseEvent::occur($this->aggregateRootId, ['foo' => 'bar']));
     }
 
+    #[Listener(BaseEvent::class)]
     protected function applyBaseEvent(BaseEvent $event): void
     {
         $this->foo = $event->getPayload()['foo'];

--- a/tests/Projection/ProjectorTest.php
+++ b/tests/Projection/ProjectorTest.php
@@ -5,38 +5,28 @@ namespace MyOnlineStore\EventSourcing\Tests\Projection;
 
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Event\BaseEvent;
-use MyOnlineStore\EventSourcing\Projection\Projector;
+use MyOnlineStore\EventSourcing\Tests\Mock\BaseProjector;
 use PHPUnit\Framework\TestCase;
 
 final class ProjectorTest extends TestCase
 {
     private \stdClass $model;
-    private Projector $projector;
+    private BaseProjector $projector;
 
     protected function setUp(): void
     {
         $this->model = new \stdClass();
-        $this->projector = new class ($this->model) extends Projector
-        {
-            private \stdClass $model;
-
-            public function __construct(\stdClass $model)
-            {
-                $this->model = $model;
-            }
-
-            protected function applyBaseEvent(BaseEvent $event): void
-            {
-                $this->model->foo = $event->getPayload()['foo'];
-            }
-        };
+        $this->projector = new BaseProjector($this->model);
     }
 
     public function testInvokeDispatchesEventToHandlerMethod(): void
     {
-        $aggregateRootId = $this->createMock(AggregateRootId::class);
-
-        ($this->projector)(BaseEvent::occur($aggregateRootId, ['foo' => 'bar']));
+        ($this->projector)(
+            BaseEvent::occur(
+                $this->createMock(AggregateRootId::class),
+                ['foo' => 'bar']
+            )
+        );
 
         self::assertSame('bar', $this->model->foo);
     }

--- a/tests/Repository/DBALMetadataRepositoryTest.php
+++ b/tests/Repository/DBALMetadataRepositoryTest.php
@@ -37,7 +37,7 @@ final class DBALMetadataRepositoryTest extends TestCase
 
         $this->connection->expects(self::once())
             ->method('fetchAssociative')
-            ->with('SELECT metadata FROM stream_metadata WHERE aggregate_id = ?', ['agg-id'], ['string'])
+            ->with('SELECT metadata FROM ' . $streamName . '_metadata WHERE aggregate_id = ?', ['agg-id'])
             ->willReturn(
                 [
                     'aggregate_id' => 'agg-id',
@@ -64,7 +64,7 @@ final class DBALMetadataRepositoryTest extends TestCase
 
         $this->connection->expects(self::once())
             ->method('fetchAssociative')
-            ->with('SELECT metadata FROM stream_metadata WHERE aggregate_id = ?', ['agg-id'], ['string'])
+            ->with('SELECT metadata FROM ' . $streamName . '_metadata WHERE aggregate_id = ?', ['agg-id'])
             ->willReturn(false);
 
         $this->jsonEncoder->expects(self::never())->method('decode');
@@ -107,7 +107,7 @@ final class DBALMetadataRepositoryTest extends TestCase
         $this->connection->expects(self::once())
             ->method('executeStatement')
             ->with(
-                'INSERT INTO stream_metadata (aggregate_id, metadata) VALUES (:aggregate_id, :metadata)
+                'INSERT INTO ' . $streamName . '_metadata (aggregate_id, metadata) VALUES (:aggregate_id, :metadata)
             ON CONFLICT (aggregate_id) DO UPDATE SET metadata = :metadata',
                 [
                     'aggregate_id' => 'agg-id',


### PR DESCRIPTION
BREAKING CHANGE: The `apply*EventName*` logic has been removed

This PR changes how event handlers are defined. Previously, the method was named after the event class. This is no longer needed. Moreover, it is now possible to have the same handler for multiple events. See the updated docs/quickstart for details.