### PR TITLE
feat(CASH-2407)!: Use `MessageDispatcher` instead of `MessageBusInterface` directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "defuse/php-encryption": "^2.3",
         "myonlinestore/coding-standard": "^3.1",
-        "myonlinestore/message-dispatcher": "dev-dispatcher",
+        "myonlinestore/message-dispatcher": "^1.0",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16",
         "vimeo/psalm": "^4.9"

--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,30 @@
     "config": {
         "sort-packages": true
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/MyOnlineStore/message-dispatcher"
+        }
+    ],
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "defuse/php-encryption": "^2.3",
         "doctrine/dbal": "^2.13 || ^3.1",
         "psr/event-dispatcher": "^1.0",
         "ramsey/uuid": "^3.9 || ^4.0",
-        "symfony/messenger": "^5.3",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {
+        "defuse/php-encryption": "^2.3",
         "myonlinestore/coding-standard": "^3.1",
+        "myonlinestore/message-dispatcher": "dev-dispatcher",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16",
-        "vimeo/psalm": "^4.8"
+        "vimeo/psalm": "^4.9"
+    },
+    "suggest": {
+        "defuse/php-encryption": "To use encrypting events",
+        "myonlinestore/message-dispatcher": "To use MessageDispatchingEventRepository"
     }
 }

--- a/src/Repository/MessageDispatchingEventRepository.php
+++ b/src/Repository/MessageDispatchingEventRepository.php
@@ -6,13 +6,13 @@ namespace MyOnlineStore\EventSourcing\Repository;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Event\Stream;
 use MyOnlineStore\EventSourcing\Event\StreamMetadata;
-use Symfony\Component\Messenger\MessageBusInterface;
+use MyOnlineStore\MessageDispatcher\MessageDispatcher;
 
-final class SymfonyMessengerEventRepository implements EventRepository
+final class MessageDispatchingEventRepository implements EventRepository
 {
     public function __construct(
         private EventRepository $innerRepository,
-        private MessageBusInterface $messageBus,
+        private MessageDispatcher $messageDispatcher,
     ) {
     }
 
@@ -21,7 +21,7 @@ final class SymfonyMessengerEventRepository implements EventRepository
         $this->innerRepository->appendTo($streamName, $aggregateRootId, $eventStream);
 
         foreach ($eventStream as $event) {
-            $this->messageBus->dispatch($event);
+            $this->messageDispatcher->dispatch($event);
         }
     }
 


### PR DESCRIPTION
- [x] https://github.com/MyOnlineStore/message-dispatcher/pull/1


This will allow the use of the `DelayedMessageDispatcher` that dispatches the messages on kernel terminate.

Makes the package a bit smaller by no longer including `defuse/php-encryption` by default. Consumer that need this package can include it themselves.