### PR TITLE
chore: Added fromAggregateRootId constructor to AggregateRootId

### DIFF
--- a/src/Aggregate/AggregateRootId.php
+++ b/src/Aggregate/AggregateRootId.php
@@ -18,6 +18,14 @@ class AggregateRootId
     }
 
     /**
+     * @psalm-pure
+     */
+    public static function fromAggregateRootId(self $aggregateRootId): static
+    {
+        return new static($aggregateRootId->id);
+    }
+
+    /**
      * @throws AssertionFailed
      *
      * @psalm-pure

--- a/tests/Aggregate/AggregateRootIdTest.php
+++ b/tests/Aggregate/AggregateRootIdTest.php
@@ -20,6 +20,16 @@ final class AggregateRootIdTest extends TestCase
         );
     }
 
+    public function testFromAggregateRootId(): void
+    {
+        $aggregateRootId = AggregateRootId::generate();
+
+        $concreteAggregateRootId = ConcreteAggregateRootId::fromAggregateRootId($aggregateRootId);
+
+        self::assertInstanceOf(ConcreteAggregateRootId::class, $concreteAggregateRootId);
+        self::assertSame($aggregateRootId->toString(), $concreteAggregateRootId->toString());
+    }
+
     public function testFromStringWithValidUuid(): void
     {
         $aggregateRootId = AggregateRootId::fromString('8311db73-de57-4fb0-b8bc-84dc37296c1e');

--- a/tests/Aggregate/ConcreteAggregateRootId.php
+++ b/tests/Aggregate/ConcreteAggregateRootId.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace MyOnlineStore\EventSourcing\Tests\Aggregate;
+
+use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
+
+/**
+ * @psalm-immutable
+ */
+final class ConcreteAggregateRootId extends AggregateRootId
+{
+}


### PR DESCRIPTION
Strugged with reflection, phpunit mocks and anonymous classes to declare `ConcreteAggregateRootId` within the unit test method, but gave up :sweat_smile: (let me know if anyone else finds another way though, besides using eval!) In the end I just declared the class in a separate file :smile: 