### PR TITLE
chore!: Change `Event::(from|to)Array` from snake_case to camelCase

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+    -   package-ecosystem: 'github-actions'
+        directory: '/'
+        schedule:
+            interval: 'daily'

--- a/src/Event/ArraySerializable.php
+++ b/src/Event/ArraySerializable.php
@@ -7,9 +7,9 @@ interface ArraySerializable extends Event
 {
     /**
      * @param array{
-     *     event_id: string,
-     *     aggregate_id: string,
-     *     created_at: string,
+     *     eventId: string,
+     *     aggregateId: string,
+     *     createdAt: string,
      *     metadata: array<string, scalar|array|null>,
      *     payload: array<string, scalar|array|null>,
      *     version: int
@@ -19,9 +19,9 @@ interface ArraySerializable extends Event
 
     /**
      * @return array{
-     *     event_id: string,
-     *     aggregate_id: string,
-     *     created_at: string,
+     *     eventId: string,
+     *     aggregateId: string,
+     *     createdAt: string,
      *     metadata: array<string, scalar|array|null>,
      *     payload: array<string, scalar|array|null>,
      *     version: int

--- a/src/Event/BaseEvent.php
+++ b/src/Event/BaseEvent.php
@@ -15,32 +15,25 @@ class BaseEvent implements ArraySerializable
     private const CREATED_FORMAT = 'Y-m-d H:i:s.u';
 
     private EventId $id;
-    private AggregateRootId $aggregateId;
     private \DateTimeImmutable $createdAt;
-
-    /** @var array<string, scalar|array|null> */
-    private array $metadata;
-
-    /** @var array<string, scalar|array|null> */
-    private array $payload;
     private int $version;
 
     /**
      * @param array<string, scalar|array|null> $payload
      * @param array<string, scalar|array|null> $metadata
      */
-    final private function __construct(AggregateRootId $aggregateId, array $payload, array $metadata = [])
-    {
-        $this->aggregateId = $aggregateId;
-        $this->payload = $payload;
-        $this->metadata = $metadata;
+    final private function __construct(
+        private AggregateRootId $aggregateId,
+        private array $payload,
+        private array $metadata = []
+    ) {
     }
 
     /**
      * @param array{
-     *     event_id: string,
-     *     aggregate_id: string,
-     *     created_at: string,
+     *     eventId: string,
+     *     aggregateId: string,
+     *     createdAt: string,
      *     metadata: array<string, scalar|array|null>,
      *     payload: array<string, scalar|array|null>,
      *     version: int
@@ -54,17 +47,17 @@ class BaseEvent implements ArraySerializable
      */
     public static function fromArray(array $data): Event
     {
-        Assert::keyExists($data, 'event_id');
-        Assert::keyExists($data, 'aggregate_id');
+        Assert::keyExists($data, 'eventId');
+        Assert::keyExists($data, 'aggregateId');
         Assert::keyExists($data, 'payload');
         Assert::keyExists($data, 'metadata');
-        Assert::keyExists($data, 'created_at');
+        Assert::keyExists($data, 'createdAt');
         Assert::keyExists($data, 'version');
 
-        $event = new static(AggregateRootId::fromString($data['aggregate_id']), $data['payload'], $data['metadata']);
-        $event->id = EventId::fromString($data['event_id']);
+        $event = new static(AggregateRootId::fromString($data['aggregateId']), $data['payload'], $data['metadata']);
+        $event->id = EventId::fromString($data['eventId']);
         /** @psalm-suppress PossiblyFalsePropertyAssignmentValue */
-        $event->createdAt = \DateTimeImmutable::createFromFormat(self::CREATED_FORMAT, $data['created_at']);
+        $event->createdAt = \DateTimeImmutable::createFromFormat(self::CREATED_FORMAT, $data['createdAt']);
         $event->version = $data['version'];
 
         return $event;
@@ -127,9 +120,9 @@ class BaseEvent implements ArraySerializable
 
     /**
      * @return array{
-     *     event_id: string,
-     *     aggregate_id: string,
-     *     created_at: string,
+     *     eventId: string,
+     *     aggregateId: string,
+     *     createdAt: string,
      *     metadata: array<string, scalar|array|null>,
      *     payload: array<string, scalar|array|null>,
      *     version: int
@@ -138,9 +131,9 @@ class BaseEvent implements ArraySerializable
     public function toArray(): array
     {
         return [
-            'event_id' => (string) $this->id,
-            'aggregate_id' => (string) $this->aggregateId,
-            'created_at' => $this->createdAt->format(self::CREATED_FORMAT),
+            'eventId' => (string) $this->id,
+            'aggregateId' => (string) $this->aggregateId,
+            'createdAt' => $this->createdAt->format(self::CREATED_FORMAT),
             'metadata' => $this->metadata,
             'payload' => $this->payload,
             'version' => $this->version,

--- a/src/Event/EventConverter.php
+++ b/src/Event/EventConverter.php
@@ -7,9 +7,9 @@ interface EventConverter
 {
     /**
      * @return array{
-     *     aggregate_id: string,
-     *     created_at: string,
-     *     event_id: string,
+     *     aggregateId: string,
+     *     createdAt: string,
+     *     eventId: string,
      *     metadata: array<string, scalar|array|null>,
      *     payload: array<string, scalar|array|null>,
      *     version: int
@@ -20,9 +20,9 @@ interface EventConverter
     /**
      * @param class-string<Event> $eventName
      * @param array{
-     *     aggregate_id: string,
-     *     created_at: string,
-     *     event_id: string,
+     *     aggregateId: string,
+     *     createdAt: string,
+     *     eventId: string,
      *     metadata: array<string, scalar|array|null>,
      *     payload: array<string, scalar|array|null>,
      *     version: int

--- a/tests/Event/ArraySerializableEventConverterTest.php
+++ b/tests/Event/ArraySerializableEventConverterTest.php
@@ -25,9 +25,9 @@ final class ArraySerializableEventConverterTest extends TestCase
     public function testCreateFromArray(): void
     {
         $data = [
-            'event_id' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
-            'aggregate_id' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
-            'created_at' => '2019-08-21 14:31:30.374',
+            'eventId' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
+            'aggregateId' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
+            'createdAt' => '2019-08-21 14:31:30.374',
             'payload' => ['foo' => 'bar'],
             'metadata' => ['baz' => 'qux'],
             'version' => 5,

--- a/tests/Event/BaseEventTest.php
+++ b/tests/Event/BaseEventTest.php
@@ -16,8 +16,8 @@ final class BaseEventTest extends TestCase
         yield [[]];
         yield [
             [
-                'aggregate_id' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
-                'created_at' => '2019-08-21 14:31:30.374870',
+                'aggregateId' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
+                'createdAt' => '2019-08-21 14:31:30.374870',
                 'metadata' => [],
                 'payload' => [],
                 'version' => 5,
@@ -25,8 +25,8 @@ final class BaseEventTest extends TestCase
         ];
         yield [
             [
-                'event_id' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
-                'created_at' => '2019-08-21 14:31:30.374870',
+                'eventId' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
+                'createdAt' => '2019-08-21 14:31:30.374870',
                 'metadata' => [],
                 'payload' => [],
                 'version' => 5,
@@ -34,8 +34,8 @@ final class BaseEventTest extends TestCase
         ];
         yield [
             [
-                'event_id' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
-                'aggregate_id' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
+                'eventId' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
+                'aggregateId' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
                 'metadata' => [],
                 'payload' => [],
                 'version' => 5,
@@ -43,27 +43,27 @@ final class BaseEventTest extends TestCase
         ];
         yield [
             [
-                'event_id' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
-                'aggregate_id' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
-                'created_at' => '2019-08-21 14:31:30.374870',
+                'eventId' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
+                'aggregateId' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
+                'createdAt' => '2019-08-21 14:31:30.374870',
                 'payload' => [],
                 'version' => 5,
             ],
         ];
         yield [
             [
-                'event_id' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
-                'aggregate_id' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
-                'created_at' => '2019-08-21 14:31:30.374870',
+                'eventId' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
+                'aggregateId' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
+                'createdAt' => '2019-08-21 14:31:30.374870',
                 'metadata' => [],
                 'version' => 5,
             ],
         ];
         yield [
             [
-                'event_id' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
-                'aggregate_id' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
-                'created_at' => '2019-08-21 14:31:30.374870',
+                'eventId' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
+                'aggregateId' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
+                'createdAt' => '2019-08-21 14:31:30.374870',
                 'metadata' => [],
                 'payload' => [],
             ],
@@ -85,9 +85,9 @@ final class BaseEventTest extends TestCase
     {
         $event = BaseEvent::fromArray(
             [
-                'event_id' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
-                'aggregate_id' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
-                'created_at' => '2019-08-21 14:31:30.374870',
+                'eventId' => '8311db73-de57-4fb0-b8bc-84dc37296c1e',
+                'aggregateId' => '7311db73-de57-4fb0-b8bc-84dc37296c1f',
+                'createdAt' => '2019-08-21 14:31:30.374870',
                 'payload' => ['foo' => 'bar'],
                 'metadata' => ['baz' => 'qux'],
                 'version' => 5,
@@ -136,9 +136,9 @@ final class BaseEventTest extends TestCase
         $event = BaseEvent::occur($aggregateId, ['foo' => 'bar']);
         $array = $event->toArray();
 
-        self::assertSame($array['event_id'], (string) $event->getId());
-        self::assertSame($array['aggregate_id'], '7311db73-de57-4fb0-b8bc-84dc37296c1f');
-        self::assertSame($array['created_at'], $event->getCreatedAt()->format('Y-m-d H:i:s.u'));
+        self::assertSame($array['eventId'], (string) $event->getId());
+        self::assertSame($array['aggregateId'], '7311db73-de57-4fb0-b8bc-84dc37296c1f');
+        self::assertSame($array['createdAt'], $event->getCreatedAt()->format('Y-m-d H:i:s.u'));
         self::assertSame($array['metadata'], $event->getMetadata());
         self::assertSame($array['payload'], $event->getPayload());
         self::assertSame($array['version'], $event->getVersion());

--- a/tests/Repository/DBALEventRepositoryTest.php
+++ b/tests/Repository/DBALEventRepositoryTest.php
@@ -47,19 +47,19 @@ final class DBALEventRepositoryTest extends TestCase
             ->method('convertToArray')
             ->willReturnOnConsecutiveCalls(
                 [
-                    'event_id' => 'event1a',
-                    'aggregate_id' => 'event1f',
+                    'eventId' => 'event1a',
+                    'aggregateId' => 'event1f',
                     'payload' => 'event1b',
                     'metadata' => 'event1c',
-                    'created_at' => 'event1d',
+                    'createdAt' => 'event1d',
                     'version' => 'event1e',
                 ],
                 [
-                    'event_id' => 'event2a',
-                    'aggregate_id' => 'event2f',
+                    'eventId' => 'event2a',
+                    'aggregateId' => 'event2f',
                     'payload' => 'event2b',
                     'metadata' => 'event2c',
-                    'created_at' => 'event2d',
+                    'createdAt' => 'event2d',
                     'version' => 'event2e',
                 ]
             );
@@ -180,11 +180,11 @@ final class DBALEventRepositoryTest extends TestCase
                 [
                     'event1',
                     [
-                        'event_id' => 'id1',
-                        'aggregate_id' => 'agg-id',
+                        'eventId' => 'id1',
+                        'aggregateId' => 'agg-id',
                         'payload' => 'pay1',
                         'metadata' => 'met1',
-                        'created_at' => 'ts1',
+                        'createdAt' => 'ts1',
                         'version' => 'v1',
                     ],
                     $metadata,
@@ -192,11 +192,11 @@ final class DBALEventRepositoryTest extends TestCase
                 [
                     'event2',
                     [
-                        'event_id' => 'id2',
-                        'aggregate_id' => 'agg-id',
+                        'eventId' => 'id2',
+                        'aggregateId' => 'agg-id',
                         'payload' => 'pay2',
                         'metadata' => 'met2',
-                        'created_at' => 'ts2',
+                        'createdAt' => 'ts2',
                         'version' => 'v2',
                     ],
                     $metadata,
@@ -278,11 +278,11 @@ final class DBALEventRepositoryTest extends TestCase
                 [
                     'event1',
                     [
-                        'event_id' => 'id1',
-                        'aggregate_id' => 'agg-id',
+                        'eventId' => 'id1',
+                        'aggregateId' => 'agg-id',
                         'payload' => 'pay1',
                         'metadata' => 'met1',
-                        'created_at' => 'ts1',
+                        'createdAt' => 'ts1',
                         'version' => 'v1',
                     ],
                     $metadata,
@@ -290,11 +290,11 @@ final class DBALEventRepositoryTest extends TestCase
                 [
                     'event2',
                     [
-                        'event_id' => 'id2',
-                        'aggregate_id' => 'agg-id',
+                        'eventId' => 'id2',
+                        'aggregateId' => 'agg-id',
                         'payload' => 'pay2',
                         'metadata' => 'met2',
-                        'created_at' => 'ts2',
+                        'createdAt' => 'ts2',
                         'version' => 'v2',
                     ],
                     $metadata,


### PR DESCRIPTION
Conform latest agreements. 

Note that storage is not affected, thus storage is backwards compatible. Nevertheless, this is still a breaking change for code relying on the array representation of events; thus this must be released as new major version.