### PR TITLE
fix: Set timezone when reconstructing an event via `BaseEvent::fromArray()`

### DIFF
--- a/src/Event/BaseEvent.php
+++ b/src/Event/BaseEvent.php
@@ -57,7 +57,11 @@ class BaseEvent implements ArraySerializable
         $event = new static(AggregateRootId::fromString($data['aggregateId']), $data['payload'], $data['metadata']);
         $event->id = EventId::fromString($data['eventId']);
         /** @psalm-suppress PossiblyFalsePropertyAssignmentValue */
-        $event->createdAt = \DateTimeImmutable::createFromFormat(self::CREATED_FORMAT, $data['createdAt']);
+        $event->createdAt = \DateTimeImmutable::createFromFormat(
+            self::CREATED_FORMAT,
+            $data['createdAt'],
+            new \DateTimeZone('UTC')
+        );
         $event->version = $data['version'];
 
         return $event;

--- a/tests/Event/BaseEventTest.php
+++ b/tests/Event/BaseEventTest.php
@@ -96,7 +96,11 @@ final class BaseEventTest extends TestCase
 
         self::assertEquals(EventId::fromString('8311db73-de57-4fb0-b8bc-84dc37296c1e'), $event->getId());
         self::assertEquals(
-            \DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', '2019-08-21 14:31:30.374870'),
+            \DateTimeImmutable::createFromFormat(
+                'Y-m-d H:i:s.u',
+                '2019-08-21 14:31:30.374870',
+                new \DateTimeZone('UTC')
+            ),
             $event->getCreatedAt()
         );
         self::assertSame(['foo' => 'bar'], $event->getPayload());


### PR DESCRIPTION
Currently, the timezone is set to `UTC` when an event is constructed,
but this is not the case when reconstructing it from an array.