### PR TITLE
chore: Return a clone of the object from `InMemoryAggregateRepository::load()`

### DIFF
--- a/src/Aggregate/AggregateFactory.php
+++ b/src/Aggregate/AggregateFactory.php
@@ -8,7 +8,11 @@ use MyOnlineStore\EventSourcing\Event\Stream;
 interface AggregateFactory
 {
     /**
-     * @psalm-param class-string<AggregateRoot> $aggregateName
+     * @param class-string<T> $aggregateName
+     *
+     * @return T
+     *
+     * @template T of AggregateRoot
      */
     public function reconstituteFromHistory(
         string $aggregateName,

--- a/src/Aggregate/FQCNAggregateFactory.php
+++ b/src/Aggregate/FQCNAggregateFactory.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 namespace MyOnlineStore\EventSourcing\Aggregate;
 
 use MyOnlineStore\EventSourcing\Event\Stream;
-use MyOnlineStore\EventSourcing\Service\Assert;
 
 final class FQCNAggregateFactory implements AggregateFactory
 {
+    /**
+     * @param class-string<T> $aggregateName
+     *
+     * @return T
+     *
+     * @template T of AggregateRoot
+     */
     public function reconstituteFromHistory(
         string $aggregateName,
         AggregateRootId $aggregateRootId,
         Stream $eventStream
     ): AggregateRoot {
-        Assert::classExists($aggregateName);
-        /** @psalm-suppress DocblockTypeContradiction */
-        Assert::subclassOf($aggregateName, AggregateRoot::class);
-
-        /** @var AggregateRoot $aggregateName */
-
         return $aggregateName::reconstituteFromHistory($aggregateRootId, $eventStream);
     }
 }

--- a/src/Listener/AttributeListenerAware.php
+++ b/src/Listener/AttributeListenerAware.php
@@ -7,7 +7,7 @@ use MyOnlineStore\EventSourcing\Listener\Attribute\Listener;
 
 trait AttributeListenerAware
 {
-    /** @var array<string, list<callable>> */
+    /** @var array<string, array<string, list<callable>>> */
     private array $listeners = [];
 
     /**
@@ -15,23 +15,25 @@ trait AttributeListenerAware
      */
     protected function getListeners(string $event): array
     {
-        if (empty($this->listeners)) {
+        $objectHash = \spl_object_hash($this);
+
+        if (!isset($this->listeners[$objectHash]) || empty($this->listeners[$objectHash])) {
             $reflection = new \ReflectionObject($this);
 
             foreach ($reflection->getMethods() as $method) {
                 foreach ($method->getAttributes(Listener::class) as $listenerAttribute) {
                     $listener = $listenerAttribute->newInstance();
 
-                    if (!isset($this->listeners[$listener->event])) {
-                        $this->listeners[$listener->event] = [];
+                    if (!isset($this->listeners[$objectHash][$listener->event])) {
+                        $this->listeners[$objectHash][$listener->event] = [];
                     }
 
-                    $this->listeners[$listener->event][] = [$this, $method->getName()];
+                    $this->listeners[$objectHash][$listener->event][] = [$this, $method->getName()];
                 }
             }
         }
 
         /** @psalm-var array<string, list<callable>> */
-        return $this->listeners[$event] ?? [];
+        return $this->listeners[$objectHash][$event] ?? [];
     }
 }

--- a/src/Repository/AggregateRepository.php
+++ b/src/Repository/AggregateRepository.php
@@ -6,9 +6,18 @@ namespace MyOnlineStore\EventSourcing\Repository;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRoot;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 
+/**
+ * @template T of AggregateRoot
+ */
 interface AggregateRepository
 {
+    /**
+     * @return T
+     */
     public function load(AggregateRootId $aggregateRootId): AggregateRoot;
 
+    /**
+     * @param T $aggregateRoot
+     */
     public function save(AggregateRoot $aggregateRoot): void;
 }

--- a/src/Repository/AggregateRepository.php
+++ b/src/Repository/AggregateRepository.php
@@ -8,6 +8,7 @@ use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 
 /**
  * @template T of AggregateRoot
+ * @template-covariant T
  */
 interface AggregateRepository
 {

--- a/src/Repository/AggregateRepository.php
+++ b/src/Repository/AggregateRepository.php
@@ -8,7 +8,6 @@ use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 
 /**
  * @template T of AggregateRoot
- * @template-covariant T
  */
 interface AggregateRepository
 {

--- a/src/Repository/InMemoryAggregateRepository.php
+++ b/src/Repository/InMemoryAggregateRepository.php
@@ -33,7 +33,7 @@ final class InMemoryAggregateRepository implements AggregateRepository
             );
         }
 
-        return $this->aggregates[$aggregateRootId->toString()];
+        return clone $this->aggregates[$aggregateRootId->toString()];
     }
 
     public function save(AggregateRoot $aggregateRoot): void

--- a/src/Repository/InMemoryAggregateRepository.php
+++ b/src/Repository/InMemoryAggregateRepository.php
@@ -9,13 +9,17 @@ use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Event\Stream;
 use MyOnlineStore\EventSourcing\Event\StreamMetadata;
 
+/**
+ * @template T of AggregateRoot
+ * @implements AggregateRepository<T>
+ */
 final class InMemoryAggregateRepository implements AggregateRepository
 {
-    /** @var array<string, AggregateRoot> */
+    /** @var array<string, T> */
     private array $aggregates = [];
 
     /**
-     * @param class-string<AggregateRoot> $aggregateName
+     * @param class-string<T> $aggregateName
      */
     public function __construct(
         private AggregateFactory $aggregateFactory,

--- a/tests/Aggregate/FQCNAggregateFactoryTest.php
+++ b/tests/Aggregate/FQCNAggregateFactoryTest.php
@@ -7,7 +7,6 @@ use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Aggregate\FQCNAggregateFactory;
 use MyOnlineStore\EventSourcing\Event\Stream;
 use MyOnlineStore\EventSourcing\Event\StreamMetadata;
-use MyOnlineStore\EventSourcing\Exception\AssertionFailed;
 use MyOnlineStore\EventSourcing\Tests\Mock\BaseAggregateRoot;
 use PHPUnit\Framework\TestCase;
 
@@ -33,26 +32,6 @@ final class FQCNAggregateFactoryTest extends TestCase
                 $aggregateRootId,
                 new Stream([], new StreamMetadata([]))
             )
-        );
-    }
-
-    public function testReconstituteFromHistoryWithInvalidClass(): void
-    {
-        $this->expectException(AssertionFailed::class);
-        $this->factory->reconstituteFromHistory(
-            'foobar',
-            $this->createMock(AggregateRootId::class),
-            new Stream([], new StreamMetadata([]))
-        );
-    }
-
-    public function testReconstituteFromHistoryWithNonAggregateRoot(): void
-    {
-        $this->expectException(AssertionFailed::class);
-        $this->factory->reconstituteFromHistory(
-            \stdClass::class,
-            $this->createMock(AggregateRootId::class),
-            new Stream([], new StreamMetadata([]))
         );
     }
 }

--- a/tests/Repository/InMemoryAggregateRepositoryTest.php
+++ b/tests/Repository/InMemoryAggregateRepositoryTest.php
@@ -28,13 +28,15 @@ final class InMemoryAggregateRepositoryTest extends TestCase
         );
 
         $this->repository->save($aggregateA);
+        $loadedAggregateA = $this->repository->load($aggregateIdA);
 
-        self::assertSame($aggregateA, $this->repository->load($aggregateIdA));
+        self::assertNotSame($aggregateA, $loadedAggregateA);
+        self::assertTrue($aggregateIdA->equals($loadedAggregateA->getAggregateRootId()));
 
         $aggregateIdB = AggregateRootId::generate();
         $aggregateB = $this->repository->load($aggregateIdB);
 
         self::assertInstanceOf(BaseAggregateRoot::class, $aggregateB);
-        self::assertNotSame($aggregateB, $aggregateA);
+        self::assertFalse($aggregateIdB->equals($aggregateA->getAggregateRootId()));
     }
 }


### PR DESCRIPTION
To better mimic save-load behaviour. Currently, a `save()` call isn't necessary
because of the reference to the object that is stored in the
`InMemoryAggregateRepository`.