### PR TITLE
fix: Catch `TypeError` in case the snapshot can not be unserialized

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,17 +33,17 @@
         "doctrine/dbal": "^2.13 || ^3.1",
         "psr/event-dispatcher": "^1.0",
         "ramsey/uuid": "^3.9 || ^4.0",
-        "webmozart/assert": "^1.10"
+        "webmozart/assert": "^1.11"
     },
     "require-dev": {
         "defuse/php-encryption": "^2.3",
         "myonlinestore/coding-standard": "^3.1",
         "myonlinestore/message-dispatcher": "^1.0",
-        "myonlinestore/php-devtools": "^0.2.0",
+        "myonlinestore/php-devtools": "^0.3",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16",
         "squizlabs/php_codesniffer": "dev-master",
-        "vimeo/psalm": "^4.22"
+        "vimeo/psalm": "^4.24"
     },
     "suggest": {
         "defuse/php-encryption": "To use encrypting events",

--- a/src/Repository/SnapshottingAggregateRepository.php
+++ b/src/Repository/SnapshottingAggregateRepository.php
@@ -11,34 +11,18 @@ use MyOnlineStore\EventSourcing\Exception\SnapshotNotFound;
 
 final class SnapshottingAggregateRepository implements AggregateRepository
 {
-    private AggregateRepository $innerRepository;
-    private EventRepository $eventRepository;
-    private MetadataRepository $metadataRepository;
-    private SnapshotRepository $snapshotRepository;
-    private SnapshottingAggregateFactory $aggregateFactory;
-    /** @psalm-var class-string<SnapshottingAggregateRoot> $aggregateName */
-    private string $aggregateName;
-    private string $streamName;
-
     /**
-     * @psalm-param class-string<SnapshottingAggregateRoot> $aggregateName
+     * @param class-string<SnapshottingAggregateRoot> $aggregateName
      */
     public function __construct(
-        AggregateRepository $innerRepository,
-        EventRepository $eventRepository,
-        MetadataRepository $metadataRepository,
-        SnapshotRepository $snapshotRepository,
-        SnapshottingAggregateFactory $aggregateFactory,
-        string $aggregateName,
-        string $streamName
+        private AggregateRepository $innerRepository,
+        private EventRepository $eventRepository,
+        private MetadataRepository $metadataRepository,
+        private SnapshotRepository $snapshotRepository,
+        private SnapshottingAggregateFactory $aggregateFactory,
+        private string $aggregateName,
+        private string $streamName
     ) {
-        $this->snapshotRepository = $snapshotRepository;
-        $this->eventRepository = $eventRepository;
-        $this->metadataRepository = $metadataRepository;
-        $this->innerRepository = $innerRepository;
-        $this->aggregateFactory = $aggregateFactory;
-        $this->aggregateName = $aggregateName;
-        $this->streamName = $streamName;
     }
 
     public function load(AggregateRootId $aggregateRootId): AggregateRoot
@@ -56,7 +40,7 @@ final class SnapshottingAggregateRepository implements AggregateRepository
                     $this->metadataRepository->load($this->streamName, $aggregateRootId)
                 )
             );
-        } catch (SnapshotNotFound) {
+        } catch (SnapshotNotFound | \TypeError) {
         }
 
         return $this->innerRepository->load($aggregateRootId);


### PR DESCRIPTION
In case of missing class(es), `unserialize` will return an
`__PHP_Incomplete_Class` object, causing a TypeError. In this case the
event repository should be used to reconstitute the model from events instead.