### PR TITLE
perf: Use generators in `DBALEventRepository` instead of arrays

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,9 @@
 name: Test
 
-on: push
-
-env:
-    COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+on:
+    push:
+        branches-ignore:
+            - master
 
 jobs:
     setup:

--- a/src/Aggregate/AggregateRoot.php
+++ b/src/Aggregate/AggregateRoot.php
@@ -11,7 +11,7 @@ abstract class AggregateRoot
 {
     use AttributeListenerAware;
 
-    /** @var Event[] */
+    /** @var list<Event> */
     protected array $recordedEvents = [];
     protected int $version = 0;
 
@@ -29,7 +29,7 @@ abstract class AggregateRoot
         return $this->version;
     }
 
-    /** @return Event[] */
+    /** @return list<Event> */
     public function popRecordedEvents(): array
     {
         $pending = $this->recordedEvents;

--- a/src/Aggregate/AggregateRootId.php
+++ b/src/Aggregate/AggregateRootId.php
@@ -11,7 +11,7 @@ use Ramsey\Uuid\Uuid;
 class AggregateRootId
 {
     final private function __construct(
-        private string $id,
+        private readonly string $id,
     ) {
     }
 

--- a/src/Aggregate/FQCNSnapshottingAggregateFactory.php
+++ b/src/Aggregate/FQCNSnapshottingAggregateFactory.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 namespace MyOnlineStore\EventSourcing\Aggregate;
 
 use MyOnlineStore\EventSourcing\Event\Stream;
-use MyOnlineStore\EventSourcing\Service\Assert;
 
 final class FQCNSnapshottingAggregateFactory implements SnapshottingAggregateFactory
 {
+    /**
+     * @param class-string<T> $aggregateName
+     *
+     * @return T
+     *
+     * @template T of SnapshottingAggregateRoot
+     */
     public function reconstituteFromSnapshotAndHistory(
         string $aggregateName,
         Snapshot $snapshot,
         Stream $eventStream,
     ): AggregateRoot {
-        Assert::classExists($aggregateName);
-        /** @psalm-suppress DocblockTypeContradiction */
-        Assert::subclassOf($aggregateName, SnapshottingAggregateRoot::class);
-
-        /** @var SnapshottingAggregateRoot $aggregateName */
-
         return $aggregateName::reconstituteFromSnapshotAndHistory($snapshot, $eventStream);
     }
 }

--- a/src/Aggregate/SnapshottingAggregateFactory.php
+++ b/src/Aggregate/SnapshottingAggregateFactory.php
@@ -5,13 +5,14 @@ namespace MyOnlineStore\EventSourcing\Aggregate;
 
 use MyOnlineStore\EventSourcing\Event\Stream;
 
-/** @template T of SnapshottingAggregateRoot */
 interface SnapshottingAggregateFactory
 {
     /**
      * @param class-string<T> $aggregateName
      *
      * @return T
+     *
+     * @template T of SnapshottingAggregateRoot
      */
     public function reconstituteFromSnapshotAndHistory(
         string $aggregateName,

--- a/src/Aggregate/SnapshottingAggregateRoot.php
+++ b/src/Aggregate/SnapshottingAggregateRoot.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 namespace MyOnlineStore\EventSourcing\Aggregate;
 
 use MyOnlineStore\EventSourcing\Event\Stream;
-use MyOnlineStore\EventSourcing\Service\Assert;
 
 abstract class SnapshottingAggregateRoot extends AggregateRoot
 {
     public static function reconstituteFromSnapshotAndHistory(
         Snapshot $snapshot,
         Stream $eventStream,
-    ): SnapshottingAggregateRoot {
+    ): static {
         $instance = \unserialize(\base64_decode($snapshot->getState()));
-
-        Assert::isInstanceOf($instance, self::class);
+        \assert($instance instanceof static);
 
         foreach ($eventStream as $event) {
             $instance->apply($event);

--- a/src/Event/EventId.php
+++ b/src/Event/EventId.php
@@ -11,7 +11,7 @@ use Ramsey\Uuid\Uuid;
 final class EventId
 {
     private function __construct(
-        private string $id,
+        private readonly string $id,
     ) {
     }
 

--- a/src/Event/FieldEncrypting.php
+++ b/src/Event/FieldEncrypting.php
@@ -5,6 +5,6 @@ namespace MyOnlineStore\EventSourcing\Event;
 
 interface FieldEncrypting
 {
-    /** @return string[] */
+    /** @return list<string> */
     public static function getEncryptingFields(): array;
 }

--- a/src/Event/FieldEncryptingConverter.php
+++ b/src/Event/FieldEncryptingConverter.php
@@ -8,8 +8,10 @@ use MyOnlineStore\EventSourcing\Exception\EncryptionFailed;
 
 final class FieldEncryptingConverter implements EventConverter
 {
-    public function __construct(private Encrypter $encrypter, private EventConverter $innerConverter)
-    {
+    public function __construct(
+        private readonly Encrypter $encrypter,
+        private readonly EventConverter $innerConverter,
+    ) {
     }
 
     /** @inheritDoc */

--- a/src/Event/Stream.php
+++ b/src/Event/Stream.php
@@ -6,8 +6,8 @@ namespace MyOnlineStore\EventSourcing\Event;
 /** @extends \ArrayObject<array-key, Event> */
 final class Stream extends \ArrayObject
 {
-    /** @param Event[] $events */
-    public function __construct(iterable $events, private StreamMetadata $metadata)
+    /** @param list<Event> $events */
+    public function __construct(array $events, private StreamMetadata $metadata)
     {
         parent::__construct($events);
     }

--- a/src/Repository/DBALMetadataRepository.php
+++ b/src/Repository/DBALMetadataRepository.php
@@ -5,6 +5,7 @@ namespace MyOnlineStore\EventSourcing\Repository;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Types\Types;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Event\StreamMetadata;
 use MyOnlineStore\EventSourcing\Exception\EncodingFailed;
@@ -28,7 +29,7 @@ final class DBALMetadataRepository implements MetadataRepository
         $result = $this->connection->fetchAssociative(
             'SELECT metadata FROM ' . $streamName . '_metadata WHERE aggregate_id = ?',
             [$aggregateRootId->toString()],
-            ['string'],
+            [Types::STRING],
         );
 
         /** @var array<string, string> $metadata */
@@ -43,7 +44,7 @@ final class DBALMetadataRepository implements MetadataRepository
         $this->connection->executeStatement(
             'DELETE FROM ' . $streamName . '_metadata WHERE aggregate_id = ?',
             [$aggregateRootId->toString()],
-            ['string'],
+            [Types::STRING],
         );
     }
 
@@ -61,8 +62,8 @@ final class DBALMetadataRepository implements MetadataRepository
                 'metadata' => $this->jsonEncoder->encode($metadata->getMetadata()),
             ],
             [
-                'aggregate_id' => 'string',
-                'metadata' => 'string',
+                'aggregate_id' => Types::STRING,
+                'metadata' => Types::STRING,
             ],
         );
     }

--- a/src/Repository/DBALSnapshotRepository.php
+++ b/src/Repository/DBALSnapshotRepository.php
@@ -5,14 +5,16 @@ namespace MyOnlineStore\EventSourcing\Repository;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Types\Types;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Aggregate\Snapshot;
 use MyOnlineStore\EventSourcing\Exception\SnapshotNotFound;
 
 final class DBALSnapshotRepository implements SnapshotRepository
 {
-    public function __construct(private Connection $connection)
-    {
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
     }
 
     /**
@@ -23,8 +25,8 @@ final class DBALSnapshotRepository implements SnapshotRepository
     {
         $result = $this->connection->fetchAssociative(
             'SELECT version, state FROM ' . $streamName . '_snapshot WHERE aggregate_id = ?',
-            [(string) $aggregateRootId],
-            ['string'],
+            [$aggregateRootId->toString()],
+            [Types::STRING],
         );
 
         if (!$result) {
@@ -42,14 +44,14 @@ final class DBALSnapshotRepository implements SnapshotRepository
             VALUES (:aggregate_id, :version, :state)
             ON CONFLICT (aggregate_id) DO UPDATE SET version = :version, state = :state',
             [
-                'aggregate_id' => (string) $snapshot->getAggregateRootId(),
+                'aggregate_id' => $snapshot->getAggregateRootId()->toString(),
                 'version' => $snapshot->getAggregateVersion(),
                 'state' => $snapshot->getState(),
             ],
             [
-                'aggregate_id' => 'string',
-                'version' => 'integer',
-                'state' => 'string',
+                'aggregate_id' => Types::STRING,
+                'version' => Types::INTEGER,
+                'state' => Types::STRING,
             ],
         );
     }

--- a/src/Repository/EncryptionKeyGeneratingEventRepository.php
+++ b/src/Repository/EncryptionKeyGeneratingEventRepository.php
@@ -11,9 +11,9 @@ use MyOnlineStore\EventSourcing\Event\StreamMetadata;
 final class EncryptionKeyGeneratingEventRepository implements EventRepository
 {
     public function __construct(
-        private EventRepository $innerRepository,
-        private KeyGenerator $keyGenerator,
-        private MetadataRepository $metadataRepository,
+        private readonly EventRepository $innerRepository,
+        private readonly KeyGenerator $keyGenerator,
+        private readonly MetadataRepository $metadataRepository,
     ) {
     }
 

--- a/src/Repository/EventAggregateRepository.php
+++ b/src/Repository/EventAggregateRepository.php
@@ -12,11 +12,11 @@ final class EventAggregateRepository implements AggregateRepository
 {
     /** @param class-string<AggregateRoot> $aggregateName */
     public function __construct(
-        private AggregateFactory $aggregateFactory,
-        private EventRepository $eventRepository,
-        private MetadataRepository $metadataRepository,
-        private string $aggregateName,
-        private string $streamName,
+        private readonly AggregateFactory $aggregateFactory,
+        private readonly EventRepository $eventRepository,
+        private readonly MetadataRepository $metadataRepository,
+        private readonly string $aggregateName,
+        private readonly string $streamName,
     ) {
     }
 

--- a/src/Repository/InMemoryAggregateRepository.php
+++ b/src/Repository/InMemoryAggregateRepository.php
@@ -19,10 +19,7 @@ final class InMemoryAggregateRepository implements AggregateRepository
     /** @var array<string, T> */
     private array $aggregates = [];
 
-    /**
-     * @param AggregateFactory<T> $aggregateFactory
-     * @param class-string<T>     $aggregateName
-     */
+    /** @param class-string<T> $aggregateName */
     public function __construct(
         private readonly AggregateFactory $aggregateFactory,
         private readonly string $aggregateName,

--- a/src/Repository/MessageDispatchingEventRepository.php
+++ b/src/Repository/MessageDispatchingEventRepository.php
@@ -11,8 +11,8 @@ use MyOnlineStore\MessageDispatcher\MessageDispatcher;
 final class MessageDispatchingEventRepository implements EventRepository
 {
     public function __construct(
-        private EventRepository $innerRepository,
-        private MessageDispatcher $messageDispatcher,
+        private readonly EventRepository $innerRepository,
+        private readonly MessageDispatcher $messageDispatcher,
     ) {
     }
 

--- a/src/Repository/RuntimeCachedAggregateRepository.php
+++ b/src/Repository/RuntimeCachedAggregateRepository.php
@@ -16,8 +16,9 @@ final class RuntimeCachedAggregateRepository implements AggregateRepository
     private array $aggregates = [];
 
     /** @param AggregateRepository<T> $innerRepository */
-    public function __construct(private AggregateRepository $innerRepository)
-    {
+    public function __construct(
+        private readonly AggregateRepository $innerRepository,
+    ) {
     }
 
     public function save(AggregateRoot $aggregateRoot): void

--- a/src/Repository/SnapshottingAggregateRepository.php
+++ b/src/Repository/SnapshottingAggregateRepository.php
@@ -16,9 +16,8 @@ use MyOnlineStore\EventSourcing\Exception\SnapshotNotFound;
 final class SnapshottingAggregateRepository implements AggregateRepository
 {
     /**
-     * @param AggregateRepository<T>          $innerRepository
-     * @param class-string<T>                 $aggregateName
-     * @param SnapshottingAggregateFactory<T> $aggregateFactory
+     * @param AggregateRepository<T> $innerRepository
+     * @param class-string<T>        $aggregateName
      */
     public function __construct(
         private readonly AggregateRepository $innerRepository,

--- a/tests/Aggregate/FQCNSnapshottingAggregateFactoryTest.php
+++ b/tests/Aggregate/FQCNSnapshottingAggregateFactoryTest.php
@@ -5,27 +5,23 @@ namespace MyOnlineStore\EventSourcing\Tests\Aggregate;
 
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Aggregate\FQCNSnapshottingAggregateFactory;
-use MyOnlineStore\EventSourcing\Aggregate\Snapshot;
 use MyOnlineStore\EventSourcing\Event\Stream;
 use MyOnlineStore\EventSourcing\Event\StreamMetadata;
-use MyOnlineStore\EventSourcing\Exception\AssertionFailed;
 use MyOnlineStore\EventSourcing\Tests\Mock\BaseSnapshottingAggregateRoot;
 use PHPUnit\Framework\TestCase;
 
 final class FQCNSnapshottingAggregateFactoryTest extends TestCase
 {
-    private AggregateRootId $aggregateRootId;
     private FQCNSnapshottingAggregateFactory $factory;
 
     protected function setUp(): void
     {
         $this->factory = new FQCNSnapshottingAggregateFactory();
-        $this->aggregateRootId = $this->createMock(AggregateRootId::class);
     }
 
     public function testReconstituteFromSnapshotAndHistory(): void
     {
-        $aggregateRoot = BaseSnapshottingAggregateRoot::createForTest($this->aggregateRootId);
+        $aggregateRoot = BaseSnapshottingAggregateRoot::createForTest(AggregateRootId::generate());
         $aggregateRoot->baseAction();
 
         self::assertEquals(
@@ -35,26 +31,6 @@ final class FQCNSnapshottingAggregateFactoryTest extends TestCase
                 $aggregateRoot->snapshot(),
                 new Stream([], new StreamMetadata([])),
             ),
-        );
-    }
-
-    public function testReconstituteFromHistoryWithInvalidClass(): void
-    {
-        $this->expectException(AssertionFailed::class);
-        $this->factory->reconstituteFromSnapshotAndHistory(
-            'foobar',
-            new Snapshot($this->aggregateRootId, 1, ''),
-            new Stream([], new StreamMetadata([])),
-        );
-    }
-
-    public function testReconstituteFromHistoryWithNonAggregateRoot(): void
-    {
-        $this->expectException(AssertionFailed::class);
-        $this->factory->reconstituteFromSnapshotAndHistory(
-            \stdClass::class,
-            new Snapshot($this->aggregateRootId, 1, ''),
-            new Stream([], new StreamMetadata([])),
         );
     }
 }

--- a/tests/Repository/DBALMetadataRepositoryTest.php
+++ b/tests/Repository/DBALMetadataRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace MyOnlineStore\EventSourcing\Tests\Repository;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
 use MyOnlineStore\EventSourcing\Aggregate\AggregateRootId;
 use MyOnlineStore\EventSourcing\Event\StreamMetadata;
 use MyOnlineStore\EventSourcing\Repository\DBALMetadataRepository;
@@ -13,12 +14,8 @@ use PHPUnit\Framework\TestCase;
 
 final class DBALMetadataRepositoryTest extends TestCase
 {
-    /** @var Connection&MockObject */
-    private Connection $connection;
-
-    /** @var Encoder&MockObject */
-    private Encoder $jsonEncoder;
-
+    private Connection&MockObject $connection;
+    private Encoder&MockObject $jsonEncoder;
     private DBALMetadataRepository $repository;
 
     protected function setUp(): void
@@ -86,7 +83,7 @@ final class DBALMetadataRepositoryTest extends TestCase
             ->with(
                 'DELETE FROM stream_metadata WHERE aggregate_id = ?',
                 ['agg-id'],
-                ['string'],
+                [Types::STRING],
             );
 
         $this->repository->remove($streamName, $aggregateRootId);
@@ -114,8 +111,8 @@ final class DBALMetadataRepositoryTest extends TestCase
                     'metadata' => 'foobar_json',
                 ],
                 [
-                    'aggregate_id' => 'string',
-                    'metadata' => 'string',
+                    'aggregate_id' => Types::STRING,
+                    'metadata' => Types::STRING,
                 ],
             );
 


### PR DESCRIPTION
To more efficiently fetch events from storage